### PR TITLE
Modified assertNodeExists to perform null check

### DIFF
--- a/src/NodeTrait.php
+++ b/src/NodeTrait.php
@@ -1178,7 +1178,7 @@ trait NodeTrait
      */
     protected function assertNodeExists(self $node)
     {
-        if ( ! $node->getLft() || ! $node->getRgt()) {
+        if ( is_null($node->getLft()) || is_null($node->getRgt()) ) {
             throw new LogicException('Node must exists.');
         }
 


### PR DESCRIPTION
I've suddenly started running into issues where the root folder (which now has an _lft value of 0, and an _rgt value of 0) forces the assertNodeExists check to fail.

To better perform this test, we should check if the value returned from the models attribute is null as this is the value returned if the node doesn't exist.